### PR TITLE
Add timeout handling to the ethernet gateway

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,11 @@ module.exports.usingSerialGateway = function(port, baud) {
 	return new Controller(gateway);
 };
 
-module.exports.usingEthernetGateway = function(address, port) {
+module.exports.usingEthernetGateway = function(address, port, options) {
 	address = address || "192.168.178.66";
 	port = port || 5003;
+	options = options || {};
+	options.timeOut = options.hasOwnProperty('timeOut') ? options.timeOut : 60000;
 
 	var gateway = require("net").Socket();
 
@@ -39,6 +41,7 @@ module.exports.usingEthernetGateway = function(address, port) {
 		console.log("Trying to connect...");
 		gateway.connect(port, address);
 		gateway.setEncoding("ascii");
+		gateway.setTimeout(options.timeOut);
 	}
 
 	gateway.on("connect", function() {
@@ -47,6 +50,11 @@ module.exports.usingEthernetGateway = function(address, port) {
 
 	gateway.on("error", function() {
 		console.log("Connection error");
+		setTimeout(connect, 1000);
+	});
+
+	gateway.on("timeout", function() {
+		console.log("Timeout");
 		setTimeout(connect, 1000);
 	});
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports.usingEthernetGateway = function(address, port, options) {
 	address = address || "192.168.178.66";
 	port = port || 5003;
 	options = options || {};
-	options.timeOut = options.hasOwnProperty('timeOut') ? options.timeOut : 60000;
+	options.timeout = options.hasOwnProperty('timeout') ? options.timeout : 60000;
 
 	var gateway = require("net").Socket();
 
@@ -41,11 +41,11 @@ module.exports.usingEthernetGateway = function(address, port, options) {
 		console.log("Trying to connect...");
 		gateway.connect(port, address);
 		gateway.setEncoding("ascii");
-		gateway.setTimeout(options.timeOut);
+		gateway.setTimeout(options.timeout);
 	}
 
 	gateway.on("connect", function() {
-		console.log("Connected to ethernet gatway at", address + ":" + port);
+		console.log("Connected to ethernet gateway at", address + ":" + port);
 	});
 
 	gateway.on("error", function() {
@@ -55,6 +55,7 @@ module.exports.usingEthernetGateway = function(address, port, options) {
 
 	gateway.on("timeout", function() {
 		console.log("Timeout");
+		gateway.end();
 		setTimeout(connect, 1000);
 	});
 


### PR DESCRIPTION
Please, see #1 for details.
### The simplest example

```
va mysensors = require("mysensors-controller");
var controller = mysensors.usingEthernetGateway('192.168.1.66', '5003', { timeOut: 5000 });

controller.on('sensorUpdate', function () {
  console.log('data...');
});
```
### The output

```
Trying to connect...
Initialized successfully with /home/dmytro/Contrib/mysensors-controller/lib/nodes.json
Connected to ethernet gatway at 192.168.1.66:5003
data...
data...
data...
# Here the wire was unplugged...
Timeout
Trying to connect...
Connection error
Trying to connect...
# Here the wire was plugged in...
Connected to ethernet gatway at 192.168.1.66:5003
data...
data...
data...
```
